### PR TITLE
Implemented CO2 support, tested with AZ7798

### DIFF
--- a/src/tasmotaSensorService.ts
+++ b/src/tasmotaSensorService.ts
@@ -70,14 +70,21 @@ export class tasmotaSensorService {
         break;
 
       case undefined:
-        // This is this Device status object
-        this.platform.log.debug('Setting accessory information', accessory.context.device[this.uniq_id].name);
-        this.accessory.getService(this.platform.Service.AccessoryInformation)!
-          .setCharacteristic(this.platform.Characteristic.Name, accessory.context.device[this.uniq_id].dev.name)
-          .setCharacteristic(this.platform.Characteristic.Manufacturer, accessory.context.device[this.uniq_id].dev.mf)
-          .setCharacteristic(this.platform.Characteristic.Model, accessory.context.device[this.uniq_id].dev.mdl)
-          .setCharacteristic(this.platform.Characteristic.FirmwareRevision, accessory.context.device[this.uniq_id].dev.sw)
-          .setCharacteristic(this.platform.Characteristic.SerialNumber, accessory.context.device[this.uniq_id].dev.ids[0]);
+        if ('mdi:molecule-co2' == accessory.context.device[this.uniq_id].ic) {
+          this.platform.log.debug('Creating CO2 sensor %s', accessory.context.device[this.uniq_id].name);
+          this.service = this.accessory.getService(uuid) || this.accessory.addService(this.platform.Service.CarbonDioxideSensor, accessory.context.device[this.uniq_id].name, uuid);
+          this.service.setCharacteristic(this.platform.Characteristic.Name, accessory.context.device[this.uniq_id].name);
+          this.characteristic = this.service.getCharacteristic(this.platform.Characteristic.CarbonDioxideLevel);
+        } else {
+          // This is this Device status object
+          this.platform.log.debug('Setting accessory information', accessory.context.device[this.uniq_id].name);
+          this.accessory.getService(this.platform.Service.AccessoryInformation)!
+            .setCharacteristic(this.platform.Characteristic.Name, accessory.context.device[this.uniq_id].dev.name)
+            .setCharacteristic(this.platform.Characteristic.Manufacturer, accessory.context.device[this.uniq_id].dev.mf)
+            .setCharacteristic(this.platform.Characteristic.Model, accessory.context.device[this.uniq_id].dev.mdl)
+            .setCharacteristic(this.platform.Characteristic.FirmwareRevision, accessory.context.device[this.uniq_id].dev.sw)
+            .setCharacteristic(this.platform.Characteristic.SerialNumber, accessory.context.device[this.uniq_id].dev.ids[0]);
+        }
         break;
       default:
         this.platform.log.warn('Warning: Unhandled Tasmota sensor type', accessory.context.device[this.uniq_id].dev_cla);


### PR DESCRIPTION
I have implemented support for the [AZ-7798 CO2 Monitor](https://tasmota.github.io/docs/AZ-7798/).
In the log below you can see it does not send a `device_class`, so I used the `ic` value.
I don't know if this is the right solution, but it does work.
```
2020-09-30T19:45:09.611Z Tasmota:platform Discovered -> homeassistant/sensor/5D7CEB_AZ7798_CarbonDioxide/config Extech_CO210 AZ7798 CarbonDioxide {
  name: 'Extech_CO210 AZ7798 CarbonDioxide',
  stat_t: 'tele/extech_co210/SENSOR',
  avty_t: 'tele/extech_co210/LWT',
  pl_avail: 'Online',
  pl_not_avail: 'Offline',
  uniq_id: '5D7CEB_AZ7798_CarbonDioxide',
  dev: { ids: [ '5D7CEB' ] },
  unit_of_meas: 'ppm',
  ic: 'mdi:molecule-co2',
  frc_upd: true,
  val_tpl: "{{value_json['AZ7798']['CarbonDioxide']}}",
  tasmotaType: 'sensor'
}
```