### PR TITLE
Feature CO2 and AirQuaility

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -357,6 +357,14 @@ function normalizeMessage(message) {
     console.log('ERROR: %s has an incorrectly configure MQTT Topic, please make it unique.', message.name);
   }
 
+  if (!message.dev_cla && message.uniq_id) {
+    if (message.uniq_id.match(/_(CarbonDioxide|eCO2)$/)) {
+      message.dev_cla = 'co2';
+    } else if (message.uniq_id.match(/_AirQuality$/)) {
+      message.dev_cla = 'pm25';
+    }
+  }
+
   return (message);
 }
 

--- a/src/tasmotaSensorService.ts
+++ b/src/tasmotaSensorService.ts
@@ -68,7 +68,25 @@ export class tasmotaSensorService {
         this.characteristic = this.service.getCharacteristic(this.platform.Characteristic.CurrentAmbientLightLevel);
 
         break;
+      case 'co2':
+        this.platform.log.debug('Creating %s sensor %s', accessory.context.device[this.uniq_id].dev_cla, accessory.context.device[this.uniq_id].name);
 
+        this.service = this.accessory.getService(uuid) || this.accessory.addService(this.platform.Service.CarbonDioxideSensor, accessory.context.device[this.uniq_id].name, uuid);
+
+        this.service.setCharacteristic(this.platform.Characteristic.Name, accessory.context.device[this.uniq_id].name);
+        this.characteristic = this.service.getCharacteristic(this.platform.Characteristic.CarbonDioxideLevel);
+
+        break;
+      case 'pm25':
+        this.platform.log.debug('Creating %s sensor %s', accessory.context.device[this.uniq_id].dev_cla, accessory.context.device[this.uniq_id].name);
+
+        this.service = this.accessory.getService(uuid) || this.accessory.addService(this.platform.Service.AirQualitySensor, accessory.context.device[this.uniq_id].name, uuid);
+
+        this.service.setCharacteristic(this.platform.Characteristic.Name, accessory.context.device[this.uniq_id].name);
+        this.characteristic = this.service.getCharacteristic(this.platform.Characteristic.AirParticulateDensity);
+        this.service.setCharacteristic(this.platform.Characteristic.AirParticulateSize, this.platform.Characteristic.AirParticulateSize._2_5_M);
+
+        break;
       case undefined:
         // This is this Device status object
         this.platform.log.debug('Setting accessory information', accessory.context.device[this.uniq_id].name);
@@ -124,6 +142,13 @@ export class tasmotaSensorService {
       case 'illuminance':
         // normalize LX in the range homebridge expects
         value = (value < 0.0001 ? 0.0001 : (value > 100000 ? 100000 : value));
+        break;
+      case 'co2':
+        if (value > 1200) {
+          this.service.setCharacteristic(this.platform.Characteristic.CarbonDioxideDetected, this.platform.Characteristic.CarbonDioxideDetected.CO2_LEVELS_ABNORMAL);
+        } else {
+          this.service.setCharacteristic(this.platform.Characteristic.CarbonDioxideDetected, this.platform.Characteristic.CarbonDioxideDetected.CO2_LEVELS_NORMAL);
+        }
         break;
     }
 


### PR DESCRIPTION
Hi @NorthernMan54,
The minute you merged my PR, I did finish my new implementation :-)
I think this way is better, I add the missing Device Class in the `normalizeMessage()` function based on the `uniq_id` value instead of the icon. This is more reliable and future proof: When the MQTT message contains a Device Class, it will continue working based on the `dev_cla` field.