### PR TITLE
New feature: specify a list of filters

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -71,6 +71,26 @@
         "default": "",
         "description": "Regular expression to filter discovery topic messages against. ie \"F52066|00F861\" limit discovery to these two devices."
       },
+      "filterAllow": {
+        "title": "List of allowed topics for discovery",
+        "type": "array",
+        "required": false,
+        "default": "",
+        "description": "A list of regex's specifying allowed disocvery topics. If this is non-empty all non-specified topics will be blocked.",
+        "items": {
+          "type": "string"
+        }
+      },
+      "filterDeny": {
+        "title": "List of denied topics for discovery",
+        "type": "array",
+        "required": false,
+        "default": "",
+        "description": "A list of regex's specifying topics to skip. Any matching mqtt topic will always be skipped, even if it matches a filterAllow rule.",
+        "items": {
+          "type": "string"
+        }
+      },
       "effects": {
         "title": "RGB Light Effects",
         "type": "boolean",

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -114,6 +114,45 @@ export class tasmotaPlatform implements DynamicPlatformPlugin {
     this.accessories.push(accessory);
   }
 
+  /* Check the topic against the configuration's filterList.
+   */
+  isTopicAllowed(topic: string, filter: string, filterAllow: Array<string>, filterDeny: Array<string>): boolean {
+    // debug('isTopicFiltered', topic)
+    let defaultAllow = true;
+
+    if (filter) {
+      defaultAllow = false;
+
+      if (filter && topic.match(filter)) {
+        debug('isTopicFiltered matched filter', filter);
+        return true;
+      }
+    }
+
+    if (filterAllow) {
+      defaultAllow = false;
+
+      for (const filter of filterAllow) {
+        if (topic.match(filter)) {
+          debug('isTopicFiltered matched filterAllow entry', filter);
+          return true;
+        }
+      }
+    }
+
+    if (filterDeny) {
+      for (const filter of filterDeny) {
+        if (topic.match(filter)) {
+          debug('isTopicFiltered matched filterDeny entry', filter);
+          return false;
+        }
+      }
+    }
+
+    // debug('isTopicFiltered matched none');
+    return defaultAllow;
+  }
+
   /**
    * This is an example method showing how to register discovered accessories.
    * Accessories must only be registered once, previously created accessories
@@ -162,8 +201,10 @@ export class tasmotaPlatform implements DynamicPlatformPlugin {
       // something globally unique, but constant, for example, the device serial
       // number or MAC address
 
+      // debug('topic', topic);
       // debug('filter', this.config.filter);
-      if (topic.match(this.config.filter)) {
+      // debug('filterList', this.config.filterList);
+      if (this.isTopicAllowed(topic, this.config.filter, this.config.filterAllow, this.config.filterDeny)) {
 
         let message = normalizeMessage(config);
         // debug('normalizeMessage ->', message);

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -119,13 +119,14 @@ export class tasmotaPlatform implements DynamicPlatformPlugin {
   isTopicAllowed(topic: string, filter: string, filterAllow: Array<string>, filterDeny: Array<string>): boolean {
     // debug('isTopicFiltered', topic)
     let defaultAllow = true;
+    let allowThis = false;
 
     if (filter) {
       defaultAllow = false;
 
       if (filter && topic.match(filter)) {
         debug('isTopicFiltered matched filter', filter);
-        return true;
+        allowThis = true;
       }
     }
 
@@ -135,7 +136,7 @@ export class tasmotaPlatform implements DynamicPlatformPlugin {
       for (const filter of filterAllow) {
         if (topic.match(filter)) {
           debug('isTopicFiltered matched filterAllow entry', filter);
-          return true;
+          allowThis = true;
         }
       }
     }
@@ -149,8 +150,7 @@ export class tasmotaPlatform implements DynamicPlatformPlugin {
       }
     }
 
-    // debug('isTopicFiltered matched none');
-    return defaultAllow;
+    return allowThis || defaultAllow;
   }
 
   /**

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -124,7 +124,7 @@ export class tasmotaPlatform implements DynamicPlatformPlugin {
     if (filter) {
       defaultAllow = false;
 
-      if (filter && topic.match(filter)) {
+      if (topic.match(filter)) {
         debug('isTopicFiltered matched filter', filter);
         allowThis = true;
       }


### PR DESCRIPTION
This provides two new configuration items, `filterAllow` and `filterDeny`. They take a list of regexes that will be matched against discovery message topics.

I'm someone who doesn't do well with complicated regexes. I'd much rather have a list of regexes than have to come up with a single regex to exclude all my unwanted devices. This also allows you to use a broad regex to allow and then to deny specific devices that would otherwise match.